### PR TITLE
upgrade zmq dependency from 2.7.x to 2.8.x; zmq 2.7.0 build is broken.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "npmlog": "0.0.x",
         "put": "0.0.x",
         "sprintf": "0.1.x",
-        "zmq": "2.7.x",
+        "zmq": "2.8.x",
         "split": "^0.3.0"
     },
     "optionalDependencies": {


### PR DESCRIPTION
Project does not compile because the dependency `zmq 2.7.x` does not compile.  See [zmq issue 316](https://github.com/JustinTulloss/zeromq.node/issues/316), solution in [issue 317](https://github.com/JustinTulloss/zeromq.node/issues/317).  This fix appears in `zmq 2.8.0`.  I've blindly upgraded the obelisk-client dependency on zmq to 2.8.0 and the project compiles again.  I have no idea whether this upgrade breaks anything else.  This is my first ever pull request.
